### PR TITLE
fix: fix wrong base path of gamejson-helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.2.2
+- gamejson-helper の .js ファイルが相対パスで参照されるように修正
+
 ## 1.2.1
 - gamejson-helper の .js ファイルが同梱されない問題を修正
 

--- a/gamejson-helper/vite.config.js
+++ b/gamejson-helper/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   root: "src",
+  base: "./",
   build: {
     outDir: "../dist"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/tkoolmv-namagame-kit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/tkoolmv-namagame-kit",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@akashic/eslint-config": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/tkoolmv-namagame-kit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "RPGツクールMV製ゲームをニコ生ゲームに変換するツール・テンプレートをまとめたリポジトリです。",
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
gamejson-helper のビルド後のスクリプトの参照が `/assets/〜` になっていたため、他ページに組み込む際に参照できなくなっていました。これを修正します。

自明につきセルフマージします。
