### PR TITLE
refactor scripts/releaseZip.js

### DIFF
--- a/scripts/releaseZip.js
+++ b/scripts/releaseZip.js
@@ -28,6 +28,8 @@ const packageJson = require(path.resolve(__dirname, "..", "package.json"));
 	await archive.glob(`${path.basename(zipDirPath)}/**`, {cwd: path.relative(process.cwd(), path.dirname(zipDirPath))});
 	await archive.finalize();
 	sh.rm("-Rf", zipDirPath);
-	shell.exec(`echo ${process.env.GITHUB_CLI_TOKEN} | gh auth login --with-token -h github.com`);
-	shell.exec(`gh release upload "v${version}" "${zipPath}"`);
+	// zip圧縮が完了するまで若干のラグがあるため、一定時間待機する
+	await new Promise(resolve => setTimeout(() => resolve(), 3000));
+	sh.exec(`echo ${process.env.GITHUB_CLI_TOKEN} | gh auth login --with-token -h github.com`);
+	sh.exec(`gh release upload "v${version}" "${zipPath}"`);
 })();

--- a/scripts/releaseZip.js
+++ b/scripts/releaseZip.js
@@ -9,7 +9,7 @@ const archiver = require("archiver");
 
 const tmpDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "tkoolmv-namagame-kit"));
 const tkoolmvKitDirPath = path.resolve(__dirname, "..", "dist", "tkoolmv-namagame-kit");
-const tkoolmvConverDirPath = path.resolve(__dirname, "..", "module", "tkoolmv-namagame-converter", "dist");
+const tkoolmvConverDirPath = path.resolve(__dirname, "..", "module", "tkoolmv-namagame-converter");
 const packageJson = require(path.resolve(__dirname, "..", "package.json"));
 
 (async() => {
@@ -20,7 +20,9 @@ const packageJson = require(path.resolve(__dirname, "..", "package.json"));
 	}
 	fs.mkdirSync(zipDirPath);
 	sh.cp("-Rf", path.join(tkoolmvKitDirPath, "*"), zipDirPath);
-	sh.cp(path.join(tkoolmvConverDirPath, "*.exe"), zipDirPath);
+	const converterPackageJson = require(path.join(tkoolmvConverDirPath, "package.json"));
+	const converterVersion = converterPackageJson["version"];
+	sh.cp(path.join(tkoolmvConverDirPath, "dist", `*${converterVersion}.exe`), zipDirPath);
 	const zipPath = `${zipDirPath}.zip`;
 	const ostream = fs.createWriteStream(zipPath);
 	const archive = archiver("zip");


### PR DESCRIPTION
### やったこと
* RPGツクールMVニコ生ゲーム化キットのzipファイルをリリースノートにアップロードするスクリプトに以下の変更を加えた
  * ファイルをzip化する関数の削除(zip化するファイルが1つだけ且つ処理が冗長になっていたので)
  * zipファイルに追加するexeファイル(コンバーター)をバージョン名で指定するように
  * zip圧縮が不完全な状態でリリースノートにアップロードされていたので、zip圧縮後一定時間待つように