### PR TITLE
タイトル画面起動前に動作するプラグインが正常に動作しない問題の修正

### DIFF
--- a/runtime/src/tkool/managers/SceneManager.ts
+++ b/runtime/src/tkool/managers/SceneManager.ts
@@ -32,6 +32,8 @@ function assignAsset(targetScene: g.Scene) {
 		}
 		return !anAsset;
 	});
+	// グローバル変数$data~の値更新後すぐに利用箇所への反映を行う(利用箇所の実行タイミングが不明なので)。
+	DataManager._onReset.fire();
 }
 
 function createLoadingLocalScene(): g.Scene {


### PR DESCRIPTION
### やったこと
* グローバル変数`$data~`の値更新後、すぐに利用箇所への反映を行うように